### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: java
 script: "ant ci"
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+      - ant
 jdk:
+  # prod, test: Java HostSpot 64-bit Server VM;
+  #     Java(TM) SE Runtime Environment (build 1.6.0_33-b03)
   - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8


### PR DESCRIPTION
ant is no longer included by default (or something) for openjdk6, etc.